### PR TITLE
Use full states to get state names.

### DIFF
--- a/python/goss/codegeneration.py
+++ b/python/goss/codegeneration.py
@@ -392,7 +392,8 @@ class GossCodeGenerator(CppCodeGenerator):
         ode = self.ode
 
         # State names
-        state_names = [state.name for state in ode.states]
+        state_names = [state.name for state in ode.full_states]
+
         body = ["", "// State names"]
         body.extend(
             '_state_names[{0}] = "{1}"'.format(i, name)


### PR DESCRIPTION
Somehow the change we made here: https://github.com/ComputationalPhysiology/goss/pull/41 broke some convergence tests in cbcbeat, which is why we revert this change. 

However, we will also make some changes to gotran (see https://github.com/ComputationalPhysiology/gotran/pull/43) so that https://github.com/ComputationalPhysiology/goss/issues/39 can remain closed.